### PR TITLE
Ability to override Gerrit URL

### DIFF
--- a/app/src/dist/config.yaml
+++ b/app/src/dist/config.yaml
@@ -16,9 +16,12 @@ Event buffer timeout in seconds: 15
 #
 # mergedChangeEmoji: If this list is present and non-empty, an emoji from it will be selected for notifications
 # for merged change events. Use if you want to have fun celebrating a change getting merged. :)
+# - gerritUrl: base Gerrit URL used to render change links in Slack notifications. If null base Gerrit url
+#       will be retrieved from ChangeEvent data. This can be helpful in cases when Gerrit is behind reverse http proxy
 Slack message configuration: # required
   username: "Gerrit Review Bot"
   iconUrl: "http://www.example.com/icon.png"
+#  gerritUrl: "http://localhost:8080/gerrit"
   directMessagesEnabled: false
   mergedChangeEmojiList:
   - ":clapping:"

--- a/app/src/main/java/sims/michael/gerritslackbot/EventGroupingTransformer.kt
+++ b/app/src/main/java/sims/michael/gerritslackbot/EventGroupingTransformer.kt
@@ -19,7 +19,7 @@ class EventGroupingTransformer(
         /* Reviewers Added - filters are not applied (messages will be addressed via DM if the reviewer is recognized) */
         val reviewerAddedEvents = events.filterIsInstance(ReviewerAddedEvent::class.java)
         val reviewerAddedMessages = reviewerAddedEvents.groupBy { event ->
-            EventGroup<ReviewerAddedEvent>(
+            EventGroup(
                     ReviewerAddedEvent::class.java,
                     event.change.project,
                     event.change.branch,
@@ -34,7 +34,7 @@ class EventGroupingTransformer(
         val newChanges = patchSetCreatedEvents.groupBy { event ->
             changeMatchers.firstOrNull { it.matches(event) }?.let { matcher ->
                 if (matcher.channel != null) {
-                    EventGroup<PatchSetCreatedEvent>(
+                    EventGroup(
                             PatchSetCreatedEvent::class.java,
                             event.change.project,
                             event.change.branch,
@@ -50,7 +50,7 @@ class EventGroupingTransformer(
         val newComments = commentAddedEvents.groupBy { event ->
             changeMatchers.firstOrNull { it.matches(event) }?.let { matcher ->
                 if (matcher.channel != null) {
-                    EventGroup<CommentAddedEvent>(
+                    EventGroup(
                             CommentAddedEvent::class.java,
                             event.change.project,
                             event.change.branch,
@@ -66,7 +66,7 @@ class EventGroupingTransformer(
         val mergedChanges = changeMergedEvents.groupBy { event ->
             changeMatchers.firstOrNull { it.matches(event) }?.let { matcher ->
                 if (matcher.channel != null) {
-                    EventGroup<ChangeMergedEvent>(
+                    EventGroup(
                             ChangeMergedEvent::class.java,
                             event.change.project,
                             event.change.branch,

--- a/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
+++ b/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
@@ -184,18 +184,13 @@ class EventGroupToSlackMessageTransformer(
     private fun PatchSetEvent.toSlackSummary() =
             "<${change.gerritChangeUrl()}|${change.subject?.escapeHtml()} (patch ${patchSet.number})>"
 
-    private fun ChangeEvent.gerritBaseUrl() = config.gerritUrl ?: baseUrlAndChangeNo(change.url).first
+    private fun ChangeEvent.gerritBaseUrl() =
+            config.gerritUrl ?: change.url?.let { gerritBaseUrlRegex.matchEntire(it)?.groupValues }?.get(1)
 
-    private fun ChangeAttribute.gerritChangeUrl() = when {
-        config.gerritUrl == null -> url
-        else -> "${config.gerritUrl}/${baseUrlAndChangeNo(url).second}"
-    }
+    private fun ChangeAttribute.gerritChangeUrl() =
+            if (config.gerritUrl == null) url else "${config.gerritUrl}/$number"
 
     private val gerritBaseUrlRegex = "^(http.*)/(\\d+)$".toRegex()
-    private fun baseUrlAndChangeNo(url: String?): Pair<String?, String?> {
-        val groups = url?.let { gerritBaseUrlRegex.matchEntire(it)?.groupValues }
-        return Pair(groups?.get(1), groups?.get(2))
-    }
 
     private fun CommentAddedEvent.toSlackShortComment(): String? {
         val delimiter = "\n\n"

--- a/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
+++ b/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
@@ -43,7 +43,7 @@ class EventGroupToSlackMessageTransformer(
 
     /** Returns a "reviewer added" slack message via DM is the username is recognized, null otherwise */
     private fun EventGroup<ReviewerAddedEvent>.toReviewerAddedMessage(): SlackMessage? {
-        val slackName = slackNameResolver[username]?.let { "@$it" }
+        val slackName = slackNameResolver[username]?.let { "@$it" } ?: return null
         val heading = "Hi there! You have been added as a reviewer to the following ${commitOrCommits(events.size)} " +
                 "in ${toProjectBranchPrefix()}:"
         return SlackMessage(

--- a/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
+++ b/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
@@ -188,13 +188,12 @@ class EventGroupToSlackMessageTransformer(
     private fun PatchSetEvent.toSlackSummary() =
             "<${change.gerritChangeUrl()}|${change.subject?.escapeHtml()} (patch ${patchSet.number})>"
 
+    private val gerritBaseUrlRegex = "^(http.*)/(\\d+)$".toRegex()
     private fun ChangeEvent.gerritBaseUrl() =
             config.gerritUrl ?: change.url?.let { gerritBaseUrlRegex.matchEntire(it)?.groupValues }?.get(1)
 
     private fun ChangeAttribute.gerritChangeUrl() =
             if (config.gerritUrl == null) url else "${config.gerritUrl}/$number/${currentPatchSet?.number}"
-
-    private val gerritBaseUrlRegex = "^(http.*)/(\\d+)$".toRegex()
 
     private fun CommentAddedEvent.toSlackShortComment(): String? {
         val delimiter = "\n\n"

--- a/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
+++ b/app/src/main/java/sims/michael/gerritslackbot/slack/EventGroupToSlackMessageTransformer.kt
@@ -2,7 +2,6 @@ package sims.michael.gerritslackbot.slack
 
 import io.reactivex.Flowable
 import io.reactivex.FlowableTransformer
-import okhttp3.HttpUrl
 import org.apache.commons.lang3.StringEscapeUtils
 import org.reactivestreams.Publisher
 import sims.michael.gerritslackbot.SlackNameResolver
@@ -19,6 +18,7 @@ class EventGroupToSlackMessageTransformer(
     data class Config(
             val username: String,
             val iconUrl: String? = null,
+            val gerritUrl: String? = null,
             val directMessagesEnabled: Boolean = false,
             val mergedChangeEmojiList: List<String> = emptyList()
     )
@@ -148,7 +148,7 @@ class EventGroupToSlackMessageTransformer(
     }
 
     private fun EventGroup<*>.toProjectBranchPrefix(): String {
-        val baseUrl = HttpUrl.parse(events.first().change.url).let { "${it.scheme()}://${it.host()}" }
+        val baseUrl =  events.first().gerritBaseUrl()
         val projectBranchLink = "$baseUrl/#/q/project:${project.escapeUrlParameter()}" +
                 "+branch:${branch.escapeUrlParameter()}+status:open"
         return "<$projectBranchLink|[$project:$branch]>"
@@ -181,8 +181,20 @@ class EventGroupToSlackMessageTransformer(
     private fun commitOrCommits(size: Int): String = if (size == 1) "commit" else "commits"
     private fun String.escapeHtml(): String? = StringEscapeUtils.escapeHtml4(this)
     private fun String.escapeUrlParameter(): String? = URLEncoder.encode(this, "UTF-8")
-    private fun PatchSetEvent.toSlackSummary(): String {
-        return "<${change.url}|${change.subject?.escapeHtml()} (patch ${patchSet.number})>"
+    private fun PatchSetEvent.toSlackSummary() =
+            "<${change.gerritChangeUrl()}|${change.subject?.escapeHtml()} (patch ${patchSet.number})>"
+
+    private fun ChangeEvent.gerritBaseUrl() = config.gerritUrl ?: baseUrlAndChangeNo(change.url).first
+
+    private fun ChangeAttribute.gerritChangeUrl() = when {
+        config.gerritUrl == null -> url
+        else -> "${config.gerritUrl}/${baseUrlAndChangeNo(url).second}"
+    }
+
+    private val gerritBaseUrlRegex = "^(http.*)/(\\d+)$".toRegex()
+    private fun baseUrlAndChangeNo(url: String?): Pair<String?, String?> {
+        val groups = url?.let { gerritBaseUrlRegex.matchEntire(it)?.groupValues }
+        return Pair(groups?.get(1), groups?.get(2))
     }
 
     private fun CommentAddedEvent.toSlackShortComment(): String? {

--- a/tests/src/test/java/sims/michael/gerritslackbot/YamlTests.kt
+++ b/tests/src/test/java/sims/michael/gerritslackbot/YamlTests.kt
@@ -31,8 +31,10 @@ class YamlTests {
         assertEquals("https://hooks.slack.example.com/services/id", config.slackApiUrl)
         assertEquals(15L, config.eventBufferTimeoutInSeconds)
         assertEquals(EventGroupToSlackMessageTransformer.Config(
-                "Gerrit Review Bot", "http://www.example.com/icon.png", false,
-                listOf(
+                username = "Gerrit Review Bot",
+                iconUrl = "http://www.example.com/icon.png",
+                directMessagesEnabled = false,
+                mergedChangeEmojiList = listOf(
                         ":clapping:", ":parrotbeer:", ":beers:", ":bomb:", ":animal:", ":badger:", ":homerscream:",
                         ":squirrel:", ":success:", ":arrrggghhh:", ":aw_yeah:", ":blondesassyparrot:", ":borat:",
                         ":bowdown:", ":celebrate:", ":dancing-penguin:", ":dancing_penguin:", ":dancingfood:",
@@ -62,7 +64,12 @@ class YamlTests {
                 mapOf("gerrit" to "slack", "chocolate" to "peanut butter"),
                 SSHStreamPublisher.Config("example.com", "username", listOf("somePath", "someOtherPath")),
                 "https://example.com",
-                EventGroupToSlackMessageTransformer.Config("username", "iconUrl", false, listOf(":one:", ":two:")),
+                EventGroupToSlackMessageTransformer.Config(
+                        username = "username",
+                        iconUrl = "iconUrl",
+                        directMessagesEnabled = false,
+                        mergedChangeEmojiList = listOf(":one:", ":two:")
+                ),
                 Config.HttpConfig(true, "localhost"),
                 30
         )

--- a/tests/src/test/resources/sims/michael/gerritslackbot/config.yaml
+++ b/tests/src/test/resources/sims/michael/gerritslackbot/config.yaml
@@ -16,9 +16,12 @@ Event buffer timeout in seconds: 15
 #
 # mergedChangeEmoji: If this list is present and non-empty, an emoji from it will be selected for notifications
 # for merged change events. Use if you want to have fun celebrating a change getting merged. :)
+# - gerritUrl: base Gerrit URL used to render change links in Slack notifications. If null base Gerrit url
+#       will be retrieved from ChangeEvent data. This can be helpful in cases when Gerrit is behind reverse http proxy
 Slack message configuration: # required
   username: "Gerrit Review Bot"
   iconUrl: "http://www.example.com/icon.png"
+#  gerritUrl: "http://localhost:8080/gerrit"
   directMessagesEnabled: false
   mergedChangeEmojiList:
   - ":clapping:"


### PR DESCRIPTION
- improved change and branch URL's when build based on ChangeEvent.url
- now it is possible to overwrite Gerrit base URL using
  configuration property. This helps if Gerrit is behind proxy
  and external Gerrit URL is different when the one in ChangeEvent.url