### PR TITLE
Ability to use regex when matching on project and branch names

### DIFF
--- a/app/src/dist/config.yaml
+++ b/app/src/dist/config.yaml
@@ -68,8 +68,8 @@ Gerrit to Slack username mappings:
 # List of event matchers - required
 #
 # This is a list of matcher definitions for gerrit stream events. Each item in the list has the following properties:
-# project - exact match on project OR "*" to match all - required
-# branch - exact match on branch OR "*" to match all - required
+# project - exact match on project OR "*" to match all OR regex match if value begins with ^- required
+# branch - exact match on branch OR "*" to match all OR regex match if value begins with ^ - required
 # subject - regular expression to match on any part of subject (match is case-insensitive) or "*" to match all - required
 # isVerificationOnly - boolean to match on comment added events that contain only verification approvals - optional
 #     missing or null means match both verifications and non-verifications
@@ -93,6 +93,14 @@ Event matchers:
 #- project: "*"
 #  branch: "*"
 #  subject: "^WIP: "
+
+# Drop all commits where project name starts with 'sandbox/'
+#- project: "^sandbox/.*"
+#  branch: "*"
+
+# Drop all commits where branch name starts with 'sandbox/'
+#- project: "*"
+#  branch: "^sandbox/.*"
 
 # Drop all verifications... matchers with null/missing channel consume the event without notifying
 #- project: "*"

--- a/app/src/dist/config.yaml
+++ b/app/src/dist/config.yaml
@@ -68,17 +68,17 @@ Gerrit to Slack username mappings:
 # List of event matchers - required
 #
 # This is a list of matcher definitions for gerrit stream events. Each item in the list has the following properties:
-# project - exact match on project OR "*" to match all OR regex match if value begins with ^- required
-# branch - exact match on branch OR "*" to match all OR regex match if value begins with ^ - required
-# subject - regular expression to match on any part of subject (match is case-insensitive) or "*" to match all - required
-# isVerificationOnly - boolean to match on comment added events that contain only verification approvals - optional
+# - project - regular expression to match on any part of project (match is case-insensitive) or "*" to match all - required
+# - branch - regular expression to match on any part of branch (match is case-insensitive) or "*" to match all - required
+# - subject - regular expression to match on any part of subject (match is case-insensitive) or "*" to match all - required
+# - isVerificationOnly - boolean to match on comment added events that contain only verification approvals - optional
 #     missing or null means match both verifications and non-verifications
 #     Note that a verification approval that is accompanied by a code review approval is considered a "non-verification"
 #     for the purposes of this test
-# changeKind - boolean to match on the "kind" of patch if it is a patchset-created event - optional
+# - changeKind - boolean to match on the "kind" of patch if it is a patchset-created event - optional
 #     missing or null means match any change kind
 #     commonly used to avoid notifying for trivial rebases or no code changes
-# channel - channel to notify - optional. If missing, the event will be dropped (used for filtering unwanted events)
+# - channel - channel to notify - optional. If missing, the event will be dropped (used for filtering unwanted events)
 #
 # Note that order matters... each event will be matched against each matcher in order and the first match wins.
 Event matchers:
@@ -97,10 +97,12 @@ Event matchers:
 # Drop all commits where project name starts with 'sandbox/'
 #- project: "^sandbox/.*"
 #  branch: "*"
+#  subject: "*"
 
 # Drop all commits where branch name starts with 'sandbox/'
 #- project: "*"
 #  branch: "^sandbox/.*"
+#  subject: "*"
 
 # Drop all verifications... matchers with null/missing channel consume the event without notifying
 #- project: "*"

--- a/app/src/main/java/sims/michael/gerritslackbot/model/ChangeMatcher.kt
+++ b/app/src/main/java/sims/michael/gerritslackbot/model/ChangeMatcher.kt
@@ -30,7 +30,7 @@ data class ChangeMatcher(
         get() = if (this is PatchSetCreatedEvent) patchSet.kind.toString() else null
 
     private fun String?.safeMatchesWildcardOrRegex(pattern: String) =
-            pattern == "*" || this?.safeMatches(pattern) ?: true
+            pattern == "*" || this?.safeMatches(pattern) ?: false
 
     private fun String.safeMatches(regex: String) = try {
         // Prefix with (?i) for a case-insensitive match

--- a/tests/src/test/java/sims/michael/gerritslackbot/EventGroupingTransformerTest.kt
+++ b/tests/src/test/java/sims/michael/gerritslackbot/EventGroupingTransformerTest.kt
@@ -41,22 +41,28 @@ class EventGroupingTransformerTest {
     fun can_match_events_based_on_project() {
         val eventMatchingTransformer = EventGroupingTransformer(listOf(
                 ChangeMatcher("Froboztic", "*", "*", "otherChannel"),
+                ChangeMatcher("^.*Dungeon", "*", "*", "regexChannel"),
                 ChangeMatcher("*", "*", "*", "channel")
         ))
         val groups = getEventGroupsWithTransformer(eventMatchingTransformer)
         assertNotNull(groups.firstOrNull { it.project == "Froboztic" })
+        assertNotNull(groups.firstOrNull { it.project == "The Dungeon Master" })
         assertEquals("otherChannel", groups.first { it.project == "Froboztic" }.channel)
+        assertEquals("regexChannel", groups.first { it.project == "The Dungeon Master" }.channel)
     }
 
     @Test
     fun can_match_events_based_on_branch() {
         val eventMatchingTransformer = EventGroupingTransformer(listOf(
                 ChangeMatcher("*", "feature-two", "*", "otherChannel"),
+                ChangeMatcher("*", "^my-.*$", "*", "regexChannel"),
                 ChangeMatcher("*", "*", "*", "channel")
         ))
         val groups = getEventGroupsWithTransformer(eventMatchingTransformer)
         assertNotNull(groups.firstOrNull { it.branch == "feature-two" })
+        assertNotNull(groups.firstOrNull { it.branch == "my-feature" })
         assertEquals("otherChannel", groups.first { it.branch == "feature-two" }.channel)
+        assertEquals("regexChannel", groups.first { it.branch == "my-feature" }.channel)
     }
 
     @Test

--- a/tests/src/test/resources/sims/michael/gerritslackbot/config.yaml
+++ b/tests/src/test/resources/sims/michael/gerritslackbot/config.yaml
@@ -68,17 +68,17 @@ Gerrit to Slack username mappings:
 # List of event matchers - required
 #
 # This is a list of matcher definitions for gerrit stream events. Each item in the list has the following properties:
-# project - exact match on project OR "*" to match all - required
-# branch - exact match on branch OR "*" to match all - required
-# subject - regular expression to match on any part of subject (match is case-insensitive) or "*" to match all - required
-# isVerificationOnly - boolean to match on comment added events that contain only verification approvals - optional
+# - project - regular expression to match on any part of project (match is case-insensitive) or "*" to match all - required
+# - branch - regular expression to match on any part of branch (match is case-insensitive) or "*" to match all - required
+# - subject - regular expression to match on any part of subject (match is case-insensitive) or "*" to match all - required
+# - isVerificationOnly - boolean to match on comment added events that contain only verification approvals - optional
 #     missing or null means match both verifications and non-verifications
 #     Note that a verification approval that is accompanied by a code review approval is considered a "non-verification"
 #     for the purposes of this test
-# changeKind - boolean to match on the "kind" of patch if it is a patchset-created event - optional
+# - changeKind - boolean to match on the "kind" of patch if it is a patchset-created event - optional
 #     missing or null means match any change kind
 #     commonly used to avoid notifying for trivial rebases or no code changes
-# channel - channel to notify - optional. If missing, the event will be dropped (used for filtering unwanted events)
+# - channel - channel to notify - optional. If missing, the event will be dropped (used for filtering unwanted events)
 #
 # Note that order matters... each event will be matched against each matcher in order and the first match wins.
 Event matchers:


### PR DESCRIPTION
If project or branch name starts with '^' it is treated as regex
otherwise exact match is performed.

Rationale:
- if project names follow some naming convetion
  (e.g. backend/app1, backend/app2, mobile/android/app1,
  mobile/ios/app1) it is easier to configure slack notification for
  "group" of projects like backend, mobile/ios, mobile/android instead
  of manually adding each new Gerrit project to configuration file
  when it is created
- similarly if branches follow naming convention (e.g. release/x.y.z)
  it is easier to match on such branches in generic way. This can be
  also useful e.g. when Gerrit is configured to support per developer
  sandbox branches which usually should be ignored in notifications.